### PR TITLE
keyring_open_with_pins() is gone (plus Makefile spiff-up)

### DIFF
--- a/lib/mdp/Makefile
+++ b/lib/mdp/Makefile
@@ -43,10 +43,11 @@ PLUGIN_VER =	0.1
 TOPDIR = ../..
 include $(TOPDIR)/Makefile.inc
 
-SERVALD_ROOT=/home/hawkinsw/serval/serval-dna
+SERVALD_ROOT?=/home/hawkinsw/serval/serval-dna
+SERVALD_LIB_ROOT?=/home/hawkinsw/serval/serval-dna
 
 CPPFLAGS+=-I$(SERVALD_ROOT)/ -I$(SERVALD_ROOT)/nacl/include
-LIBS+=-L$(SERVALD_ROOT) -lservald
+LIBS+=-L$(SERVALD_LIB_ROOT) -lserval
 
 default_target: $(PLUGIN_FULLNAME)
 

--- a/lib/mdp/src/olsrd_mdp.c
+++ b/lib/mdp/src/olsrd_mdp.c
@@ -1079,13 +1079,12 @@ timeout_timestamps(void *foo __attribute__ ((unused)))
 static int 
 read_key_from_servald(const char *sid)
 {
-  const char *pins = {"",};
   unsigned char stowedSid[SID_SIZE];
   unsigned char *found_private_key = NULL;
   int found_private_key_len = 0;
   int cn = 0, in = 0, kp = 0;
  
-  keyring = keyring_open_with_pins(pins);
+  keyring = keyring_open_instance();
   stowSid(stowedSid, 0, sid);
   
   if (!keyring_find_sid(keyring, &cn, &in, &kp, stowedSid))

--- a/lib/mdp/src/olsrd_mdp.c
+++ b/lib/mdp/src/olsrd_mdp.c
@@ -148,7 +148,7 @@ print_data(const char *label, const uint8_t *data, size_t len)
 static void
 mdp_checksum(uint8_t *data, const uint16_t data_len, uint8_t *hashbuf)
 {
-  unsigned long long signature_bytes = SIGNATURE_BYTES;
+  int signature_bytes = SIGNATURE_BYTES;
   print_data("Key", servald_key, servald_key_len);
   print_data("Data", data, data_len);
 


### PR DESCRIPTION
This brings the mdp plugin in line with serval-dna where keyring_open_with_pins() is no longer around. 

Also, this allows a user to place their Serval source and compiled libservald.so in separate directories!
