### PR TITLE
Fix mdp Makefile and properly open keyring file

### DIFF
--- a/lib/mdp/Makefile
+++ b/lib/mdp/Makefile
@@ -47,7 +47,7 @@ SERVALD_ROOT?=/home/hawkinsw/serval/serval-dna
 SERVALD_LIB_ROOT?=/home/hawkinsw/serval/serval-dna
 
 CPPFLAGS+=-I$(SERVALD_ROOT)/ -I$(SERVALD_ROOT)/nacl/include
-LIBS+=-L$(SERVALD_LIB_ROOT) -lserval
+LIBS+=-L$(SERVALD_LIB_ROOT) -lservald
 
 default_target: $(PLUGIN_FULLNAME)
 

--- a/lib/mdp/src/olsrd_mdp.c
+++ b/lib/mdp/src/olsrd_mdp.c
@@ -1085,6 +1085,7 @@ read_key_from_servald(const char *sid)
   int cn = 0, in = 0, kp = 0;
  
   keyring = keyring_open_instance();
+  keyring_enter_pin(keyring, "");
   stowSid(stowedSid, 0, sid);
   
   if (!keyring_find_sid(keyring, &cn, &in, &kp, stowedSid))


### PR DESCRIPTION
1. Fix the mdp Makefile: It is called libservald.so,
   not libserval.so
2. Properly open the keyring file: Must call keyring_
   enter_pin(file, ""); to get access to the default
   identities.
