### PR TITLE
Fix Issue 11

### DIFF
--- a/lib/mdp/src/olsrd_mdp.c
+++ b/lib/mdp/src/olsrd_mdp.c
@@ -1085,7 +1085,7 @@ read_key_from_servald(const char *sid)
   int cn = 0, in = 0, kp = 0;
  
   keyring = keyring_open_instance();
-  keyring_enter_pin(keyring, "");
+  keyring_enter_pin(keyring, NULL);
   stowSid(stowedSid, 0, sid);
   
   if (!keyring_find_sid(keyring, &cn, &in, &kp, stowedSid))


### PR DESCRIPTION
Use NULL rather than "" to signal that we are
not passing any pins to the keyring_enter_pin
function.

<!---
@huboard:{"order":5.5}
-->
