### PR TITLE
Attempt #1 to Fix Issue #24

### DIFF
--- a/src/net_olsr.c
+++ b/src/net_olsr.c
@@ -368,7 +368,7 @@ net_output(struct interface *ifp)
    *Call possible packet transform functions registered by plugins
    */
   for (tmp_ptf_list = ptf_list; tmp_ptf_list != NULL; tmp_ptf_list = tmp_ptf_list->next) {
-    tmp_ptf_list->function(ifp->netbuf.buff, &ifp->netbuf.pending);
+    tmp_ptf_list->function(ifp, ifp->netbuf.buff, &ifp->netbuf.pending);
   }
 
   if (olsr_cnf->ip_version == AF_INET) {

--- a/src/net_olsr.h
+++ b/src/net_olsr.h
@@ -49,7 +49,7 @@
 #include <arpa/inet.h>
 #include <net/if.h>
 
-typedef int (*packet_transform_function) (uint8_t *, int *);
+typedef int (*packet_transform_function) (struct interface *, uint8_t *, int *);
 
 void init_net(void);
 


### PR DESCRIPTION
1. Make MDP control messages always first
   in olsr packets.
2. Set originator/destination based on the
   actual outgoing interface, not the main
   address. This requires that we add a
   parameter to the packet transformation
   function (prototype and our implementation).
3. Initialize memory to 0.
